### PR TITLE
Update detail view to use recent mixin change

### DIFF
--- a/news/views.py
+++ b/news/views.py
@@ -27,5 +27,13 @@ class ArticleDetail(DetailView):
     Detail view for an news object
     """
 
-    queryset = Article.objects.published()
     template_name = "./news_detail.html"
+
+    def get_queryset(self):
+        """
+        Override the default queryset method so that we can access the request.user
+        """
+        if self.queryset is None:
+            return Article.objects.published(user=self.request.user)
+        return self.queryset
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-news"
-version = "0.1.2.3"
+version = "0.1.2.4"
 description = "A small reusable package that adds a News app to a project"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"


### PR DESCRIPTION
This change should allow admin to see unpublished detail pages rather than 404ing