### PR TITLE
Feature/settings

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,3 +29,7 @@ jobs:
           poetry run pytest
           poetry build
 
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@797e92895ec0eac368405352c0add9af878fe257  # v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.egg-info
 poetry.lock
 dist
+.coverage
+test-reports/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,6 @@
 
 ## 0.1.3
 - Add related article plugin 
+
+## 0.2.0
+- Add settings and files for tests to be run outside of a django project

--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,2 @@
 - Add a get_settings() function to reduce repeat code in admin.py
-- Add settings file. Will allow tests to be run in app without needing a project
+-Refactor urls/templates/views to not require overriding in a project. See giant-events

--- a/news/migrations/0005_relatedarticlecardplugin_relatedarticleplugin.py
+++ b/news/migrations/0005_relatedarticlecardplugin_relatedarticleplugin.py
@@ -7,31 +7,66 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '0022_auto_20180620_1551'),
-        ('news', '0004_article_category'),
+        ("cms", "0022_auto_20180620_1551"),
+        ("news", "0004_article_category"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='RelatedArticleCardPlugin',
+            name="RelatedArticleCardPlugin",
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, related_name='news_relatedarticlecardplugin', serialize=False, to='cms.CMSPlugin')),
-                ('article', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='related_articles', to='news.Article', verbose_name='Article')),
+                (
+                    "cmsplugin_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        related_name="news_relatedarticlecardplugin",
+                        serialize=False,
+                        to="cms.CMSPlugin",
+                    ),
+                ),
+                (
+                    "article",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="related_articles",
+                        to="news.Article",
+                        verbose_name="Article",
+                    ),
+                ),
             ],
-            options={
-                'abstract': False,
-            },
-            bases=('cms.cmsplugin',),
+            options={"abstract": False,},
+            bases=("cms.cmsplugin",),
         ),
         migrations.CreateModel(
-            name='RelatedArticlePlugin',
+            name="RelatedArticlePlugin",
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, related_name='news_relatedarticleplugin', serialize=False, to='cms.CMSPlugin')),
-                ('tags', models.ManyToManyField(blank=True, help_text='Select tags to add the most recent articles.', to='news.ArticleTag')),
+                (
+                    "cmsplugin_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        related_name="news_relatedarticleplugin",
+                        serialize=False,
+                        to="cms.CMSPlugin",
+                    ),
+                ),
+                (
+                    "tags",
+                    models.ManyToManyField(
+                        blank=True,
+                        help_text="Select tags to add the most recent articles.",
+                        to="news.ArticleTag",
+                    ),
+                ),
             ],
-            options={
-                'abstract': False,
-            },
-            bases=('cms.cmsplugin',),
+            options={"abstract": False,},
+            bases=("cms.cmsplugin",),
         ),
     ]

--- a/news/models.py
+++ b/news/models.py
@@ -160,7 +160,9 @@ class RelatedArticlePlugin(CMSPlugin):
     """
 
     tags = models.ManyToManyField(
-        to=ArticleTag, blank=True, help_text="Select tags to add the most recent articles."
+        to=ArticleTag,
+        blank=True,
+        help_text="Select tags to add the most recent articles.",
     )
 
     def __str__(self):

--- a/news/tests/test_models.py
+++ b/news/tests/test_models.py
@@ -1,7 +1,6 @@
 import pytest
 
 
-@pytest.importorskip("django.settings.INSTALLED_APPS")
 @pytest.mark.django_db
 class TestArticle:
     # import models here to avoid error
@@ -9,7 +8,7 @@ class TestArticle:
 
     @pytest.fixture
     def author_instance(self):
-        return self.Author.objects.create(first_name="John", last_name="Doe")
+        return self.Author.objects.create(name="John Doe")
 
     @pytest.fixture
     def article_instance(self, author_instance):
@@ -19,20 +18,18 @@ class TestArticle:
         assert str(article_instance) == f"Title article by John Doe"
 
 
-@pytest.importorskip("django.settings.INSTALLED_APPS")
 class TestArticleTag:
     # import models here to avoid error
     from news.models import ArticleTag
 
     @pytest.fixture
     def article_tag_instance(self):
-        return self.ArticleTag(tag="Tag", slug="tag")
+        return self.ArticleTag(tag="Tag")
 
     def test_str(self, article_tag_instance):
         assert str(article_tag_instance) == "Tag"
 
 
-@pytest.importorskip("django.settings.INSTALLED_APPS")
 class TestAuthor:
     # import models here to avoid error
     from news.models import Author
@@ -45,14 +42,13 @@ class TestAuthor:
         assert str(author_instance) == "John Doe"
 
 
-@pytest.importorskip("django.settings.INSTALLED_APPS")
 class TestCategory:
     # import models here to avoid error
     from news.models import Category
 
     @pytest.fixture
     def category_instance(self):
-        return self.Category(category="Category")
+        return self.Category(name="Category")
 
     def test_str(self, category_instance):
         assert str(category_instance) == "Category"

--- a/news/tests/urls.py
+++ b/news/tests/urls.py
@@ -1,0 +1,7 @@
+from django.urls import include, path
+
+""""
+Url patterns for testing
+"""
+
+urlpatterns = [path("news/", include("news.urls", namespace="news"))]

--- a/news/views.py
+++ b/news/views.py
@@ -36,4 +36,3 @@ class ArticleDetail(DetailView):
         if self.queryset is None:
             return Article.objects.published(user=self.request.user)
         return self.queryset
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ django = "2.2"
 django-cms = "^3.7.2"
 black = "^19.10b0"
 pytest-django = "^3.9.0"
+pytest-cov = "^2.10.0"
 
 [[tool.poetry.source]]
 name = "TestPyPi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ pytest = "^5.2"
 django = "2.2"
 django-cms = "^3.7.2"
 black = "^19.10b0"
+pytest-django = "^3.9.0"
 
 [[tool.poetry.source]]
 name = "TestPyPi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-news"
-version = "0.1.3"
+version = "0.2.0"
 description = "A small reusable package that adds a News app to a project"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = settings
+python_files = tests.py test_*.py *_tests.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = settings
 python_files = tests.py test_*.py *_tests.py
+addopts = --cov=news/ --cov-report=term-missing:skip-covered --cov-report=xml:test-reports/coverage.xml --no-cov-on-fail --tb=native --reuse-db

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,73 @@
+
+SECRET_KEY = "giant-news"
+DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3"}}
+INSTALLED_APPS=[
+    "cms",
+    "treebeard",
+    "menus",
+    "sekizai",
+    "easy_thumbnails",
+    "filer",
+    "mptt",
+    "djangocms_admin_style",
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.messages",
+    "django.contrib.sessions",
+    "django.contrib.sites",
+    "django.contrib.staticfiles",
+    "news",
+]
+ROOT_URLCONF="news.tests.urls"
+TEMPLATES=[
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": ["news/templates"],
+        "OPTIONS": {
+            "context_processors": [
+                "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.request",
+                "django.template.context_processors.media",
+                "django.template.context_processors.static",
+                "django.template.context_processors.tz",
+                "django.contrib.messages.context_processors.messages",
+                "sekizai.context_processors.sekizai",
+                "cms.context_processors.cms_settings",
+            ],
+            "loaders": ["django.template.loaders.app_directories.Loader",],
+        },
+    },
+]
+MIDDLEWARE=[
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "cms.middleware.user.CurrentUserMiddleware",
+    "cms.middleware.page.CurrentPageMiddleware",
+    "cms.middleware.toolbar.ToolbarMiddleware",
+    "cms.middleware.language.LanguageCookieMiddleware",
+]
+SITE_ID = 1
+
+LANGUAGE_CODE = 'en-gb'
+
+# TIME_ZONE = 'UTC'
+#
+# USE_I18N = True
+#
+# USE_L10N = True
+#
+# USE_TZ = True
+
+LANGUAGES = [
+    ('en-gb', 'English'),
+]
+
+# DEFAULT_LANGUAGE = 'en-gb'

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,8 @@
 
 SECRET_KEY = "giant-news"
+
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
+
 INSTALLED_APPS = [
     "cms",
     "treebeard",
@@ -13,47 +15,28 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
-    "django.contrib.messages",
-    "django.contrib.sessions",
     "django.contrib.sites",
-    "django.contrib.staticfiles",
     "news",
 ]
 ROOT_URLCONF = "news.tests.urls"
+
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": ["news/templates"],
         "OPTIONS": {
             "context_processors": [
-                "django.contrib.auth.context_processors.auth",
-                "django.template.context_processors.debug",
-                "django.template.context_processors.i18n",
                 "django.template.context_processors.request",
-                "django.template.context_processors.media",
-                "django.template.context_processors.static",
-                "django.template.context_processors.tz",
-                "django.contrib.messages.context_processors.messages",
-                "sekizai.context_processors.sekizai",
-                "cms.context_processors.cms_settings",
             ],
-            "loaders": ["django.template.loaders.app_directories.Loader"],
         },
     },
 ]
+
 MIDDLEWARE = [
-    "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
-    "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "cms.middleware.user.CurrentUserMiddleware",
-    "cms.middleware.page.CurrentPageMiddleware",
-    "cms.middleware.toolbar.ToolbarMiddleware",
-    "cms.middleware.language.LanguageCookieMiddleware",
 ]
+
 SITE_ID = 1
 
 LANGUAGE_CODE = 'en-gb'

--- a/settings.py
+++ b/settings.py
@@ -1,7 +1,7 @@
 
 SECRET_KEY = "giant-news"
-DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3"}}
-INSTALLED_APPS=[
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
+INSTALLED_APPS = [
     "cms",
     "treebeard",
     "menus",
@@ -19,8 +19,8 @@ INSTALLED_APPS=[
     "django.contrib.staticfiles",
     "news",
 ]
-ROOT_URLCONF="news.tests.urls"
-TEMPLATES=[
+ROOT_URLCONF = "news.tests.urls"
+TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": ["news/templates"],
@@ -37,11 +37,11 @@ TEMPLATES=[
                 "sekizai.context_processors.sekizai",
                 "cms.context_processors.cms_settings",
             ],
-            "loaders": ["django.template.loaders.app_directories.Loader",],
+            "loaders": ["django.template.loaders.app_directories.Loader"],
         },
     },
 ]
-MIDDLEWARE=[
+MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -58,16 +58,6 @@ SITE_ID = 1
 
 LANGUAGE_CODE = 'en-gb'
 
-# TIME_ZONE = 'UTC'
-#
-# USE_I18N = True
-#
-# USE_L10N = True
-#
-# USE_TZ = True
-
 LANGUAGES = [
     ('en-gb', 'English'),
 ]
-
-# DEFAULT_LANGUAGE = 'en-gb'


### PR DESCRIPTION
This PR adds the ability to run tests locally, and independent of a django project. The key features:

- add a settings file
- add `pytest-django` so that pytest can detect django settings
- Reconfigure most of the previously skipped tests as they were failing

Note that some files are changed due to `black`.