### PR TITLE
Feature/migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ poetry.lock
 dist
 .coverage
 test-reports/
+giant-news

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ To install with the package manager, run:
 You should then add `"news", "easy_thumbnails" and "filer"` to the `INSTALLED_APPS` in your settings file. 
 The detail pages in this app use plugins which are not contained within this app. It is recommended that you include a set of plugins in your project, or use the `giant-plugins` app.
 
+In order to run `django-admin` commands you will need to set the `DJANGO_SETTINGS_MODULE` by running
+
+    $ export DJANGO_SETTINGS_MODULE=settings
 
 ## Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-news"
-version = "0.2.0"
+version = "0.2.1"
 description = "A small reusable package that adds a News app to a project"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"

--- a/settings.py
+++ b/settings.py
@@ -1,7 +1,12 @@
 
 SECRET_KEY = "giant-news"
 
-DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "giant-news",
+    }
+}
 
 INSTALLED_APPS = [
     "cms",
@@ -16,6 +21,8 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sites",
+    "django.contrib.sessions",
+    "django.contrib.messages",
     "news",
 ]
 ROOT_URLCONF = "news.tests.urls"
@@ -26,8 +33,9 @@ TEMPLATES = [
         "DIRS": ["news/templates"],
         "OPTIONS": {
             "context_processors": [
+                "django.contrib.auth.context_processors.auth",
                 "django.template.context_processors.request",
-            ],
+                "django.contrib.messages.context_processors.messages",            ],
         },
     },
 ]
@@ -35,6 +43,7 @@ TEMPLATES = [
 MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
 ]
 
 SITE_ID = 1

--- a/settings.py
+++ b/settings.py
@@ -35,7 +35,8 @@ TEMPLATES = [
             "context_processors": [
                 "django.contrib.auth.context_processors.auth",
                 "django.template.context_processors.request",
-                "django.contrib.messages.context_processors.messages",            ],
+                "django.contrib.messages.context_processors.messages",
+            ],
         },
     },
 ]


### PR DESCRIPTION
This PR adds a few new settings which will allow you to run `django-admin makemigrations`. Should make the app a little easier to maintain when making changes as it won't require a project 