### PR TITLE
Fix form to only filter if tags are present

### DIFF
--- a/news/forms.py
+++ b/news/forms.py
@@ -23,4 +23,6 @@ class NewsSearchForm(forms.Form):
         Additionally apply tags filter to the results.
         """
         tags = self.cleaned_data.get("tags")
-        return self.queryset.filter(tags__in=tags)
+        if tags:
+            self.queryset = self.queryset.filter(tags__in=tags)
+        return self.queryset

--- a/news/templates/news/index.html
+++ b/news/templates/news/index.html
@@ -48,23 +48,6 @@
             {% empty %}
                 <h3>No articles currently listed</h3>
             {% endfor %}
-            <div class="pagination">
-                <span class="step-links">
-                    {% if page_obj.has_previous %}
-                        <a href="?page=1">&laquo; first</a>
-                        <a href="?page={{ page_obj.previous_page_number }}">previous</a>
-                    {% endif %}
-
-                    <span class="current">
-                        Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
-                    </span>
-
-                    {% if page_obj.has_next %}
-                        <a href="?page={{ page_obj.next_page_number }}">next</a>
-                        <a href="?page={{ page_obj.paginator.num_pages }}">last &raquo;</a>
-                    {% endif %}
-                </span>
-            </div>
         </div>
 
     </section>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-news"
-version = "0.3.0"
+version = "0.3.0.1"
 description = "A small reusable package that adds a News app to a project"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"


### PR DESCRIPTION
Fixes an issue where the pagination would break if the qs spanned across more than one page.

Have removed the base pagination from here as it's going to get a bit more complex now that the tags are needed in the querystring. If we want to have pagination in these libs we could investigate another solution but I think removing this (at least for now) is the best solution