### PR TITLE
Force order on the view to sort by publish date

### DIFF
--- a/news/tests/test_views.py
+++ b/news/tests/test_views.py
@@ -85,11 +85,11 @@ class TestArticleView:
         Test the view get_queryset returns the published qs
         """
         mock_qs = mocker.Mock(return_value="published")
-        mocker.patch.object(models.ArticleQuerySet, "published", mock_qs)
+        mocker.patch.object(models.ArticleQuerySet, "order_by", mock_qs)
         qs = view_instance.get_queryset()
 
         assert qs == "published"
-        mock_qs.assert_called_once_with(user=view_instance.request.user)
+        mock_qs.assert_called_once_with("-publish_at")
 
     def test_update_context(self, article_instance, view_instance, mocker):
         """

--- a/news/views.py
+++ b/news/views.py
@@ -18,7 +18,7 @@ class ArticleIndex(ListView):
         """
         Override get method here to allow us to filter using tags
         """
-        queryset = models.Article.objects.published(user=self.request.user)
+        queryset = models.Article.objects.published(user=self.request.user).order_by("-publish_at")
         form = forms.NewsSearchForm(data=self.request.GET or None, queryset=queryset)
         if form.is_valid():
             queryset = form.process()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-news"
-version = "0.3.2.3"
+version = "0.3.2.4"
 description = "A small reusable package that adds a News app to a project"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"


### PR DESCRIPTION
Forces the order in the view to be based on the publish date rather than defaulting to the model meta of when it was created