### PR TITLE
Unpin the dependencies so we can set in projects

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,0 @@
-- Add a get_settings() function to reduce repeat code in admin.py
--Refactor urls/templates/views to not require overriding in a project. See giant-events

--- a/news/cms_plugins.py
+++ b/news/cms_plugins.py
@@ -23,6 +23,7 @@ class RelatedArticlePlugin(CMSPluginBase):
         """
         Override the default render to allow the user to set a custom number of articles to be shown
         """
+        # TODO: prevent current page article from being repeated in the get_articles
         context = super().render(context, instance, placeholder)
         context["latest_articles"] = instance.get_articles()
         return context

--- a/news/models.py
+++ b/news/models.py
@@ -83,6 +83,8 @@ class Article(TimestampMixin, PublishingMixin):
     Model for creating and storing and Article object
     """
 
+    # TODO: Maybe add plugin text as a field so we can search against it
+
     title = models.CharField(max_length=255)
     slug = models.SlugField(max_length=255, unique=True)
     author = models.ForeignKey(
@@ -109,6 +111,7 @@ class Article(TimestampMixin, PublishingMixin):
     objects = ArticleQuerySet.as_manager()
 
     class Meta:
+        # TODO: change this to -publish_at
         ordering = ["-created_at"]
         verbose_name = "Article"
         verbose_name_plural = "Articles"
@@ -205,6 +208,8 @@ class RelatedArticlePlugin(CMSPlugin):
         """
         Return a queryset for a category
         """
+        # TODO: remove extra filter when Meta ordering changes
+
         return (
             Article.objects.published()
             .filter(category=self.category)
@@ -227,6 +232,7 @@ class RelatedArticlePlugin(CMSPlugin):
         """
         Return a default queryset
         """
+        # TODO: remove extra filter when Meta ordering changes
         return Article.objects.published().order_by("-created_at")
 
     def get_articles(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "*"
+python = "^3.6"
 giant-mixins = "*"
 django-filer = "*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ black = "^19.10b0"
 pytest-django = "^3.9.0"
 pytest-cov = "^2.10.0"
 pytest-mock = "^3.2.0"
+six = "^1.15.0"
 django-polymorphic = "3.0.0"
 
 [[tool.poetry.source]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-news"
-version = "0.3.2.4"
+version = "0.3.3"
 description = "A small reusable package that adds a News app to a project"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"
@@ -23,9 +23,9 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
-giant-mixins = "^0.1.1"
-django-filer = "^1.7.1"
+python = "*"
+giant-mixins = "*"
+django-filer = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,13 @@ django-filer = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
-django = "2.2"
-django-cms = "^3.7.2"
+django = "^3"
+django-cms = "^3"
 black = "^19.10b0"
 pytest-django = "^3.9.0"
 pytest-cov = "^2.10.0"
 pytest-mock = "^3.2.0"
+django-polymorphic = "3.0.0"
 
 [[tool.poetry.source]]
 name = "TestPyPi"


### PR DESCRIPTION
Main change is to unpin deps so that it doesn't cause errors when trying to install in the project itself