### PR TITLE
Readme migration instructions allow local tests to pass.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ admin.site.register(Article, ArticleAdmin)
 ```
 
 When the migrations are created for this new model it will need some tweaking as
-Django will not set this up to use swapper. To do this add the following line to
+Django will not set this up to use swapper. To do this add the following lines to
 the initial migration file (this will replace the hardcoded dependency on the
 0002 migration from giant_news)
 
@@ -65,6 +65,7 @@ class Migration...
 
     dependencies = [
         ...
+        ('giant_news', '0001_initial'),
         swapper.dependency("giant_news", "Article"),
     ]
 ```


### PR DESCRIPTION
After attempting to integrate version beta 1.0.0 of giant news the tests were failing locally (ValueError: Related model 'news.article' cannot be resolved) - . I found after making the proposed change in this pull request that the tests passed.