### PR TITLE
Changed way read_time property is calculated for an article based on subsection of plugins.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.5
+- Fixed bug that was causing recursion error when article card plugin was placed on an article detail page. The read_time attribute is now calculated from rich text plugins only.
+
 ## 1.2.4
 - Add optional title field to the related article plugin
 

--- a/giant_news/models/article.py
+++ b/giant_news/models/article.py
@@ -137,18 +137,18 @@ class AbstractArticle(TimestampMixin, PublishingMixin):
         return reverse("news:detail", kwargs={"slug": self.slug})
 
     @cached_property
-    def plain_text(self):
+    def rich_plugin_text(self):
         """
         Renders all the plaintext plugins from the placeholder field
         """
-
         # We need to use this weird ContentRenderer in order to render the plugins
         renderer = ContentRenderer(request=RequestFactory())
         text = ""
 
         for plugin in self.content.cmsplugin_set.all():
-            html = renderer.render_plugin(plugin, {})
-            text += strip_tags(html)
+            if plugin.plugin_type == "RichTextPlugin":
+                html = renderer.render_plugin(plugin, {})
+                text += strip_tags(html)
 
         return text.strip()
 
@@ -157,7 +157,7 @@ class AbstractArticle(TimestampMixin, PublishingMixin):
         """
         Return estimated article reading time
         """
-        word_count = len(self.plain_text.split())
+        word_count = len(self.rich_plugin_text.split())
         mins = round(word_count / 240.0)
         if word_count and mins < 1:
             return 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-news"
-version = "1.2.4"
+version = "1.2.5"
 description = "A small reusable package that adds a News app to a project"
 authors = ["Will-Hoey <will.hoey@giantdigital.co.uk>"]
 license = "MIT"
@@ -43,7 +43,7 @@ flake8 = "^6.0.0"
 [[tool.poetry.source]]
 name = "TestPyPi"
 url = "https://test.pypi.org/simple/"
-secondary = true
+priority = "secondary"
 
 [tool.black]
 line-length = 99


### PR DESCRIPTION
# Changes Summary
This prevents a recursion error when plugin is used within news app.