### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.0
+- Add Atom and RSS news feeds.
+
 ## 1.2.6
 - Assign saved plugin_text correctly for article model following from 1.2.5.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "giant-news"
-version = "1.2.6"
+version = "1.3.0"
 description = "A small reusable package that adds a News app to a project"
-authors = ["Will-Hoey <will.hoey@giantdigital.co.uk>"]
+authors = ["Will-Hoey <will.hoey@giantdigital.co.uk>", "Jon Atkinson <jon@jonatkinson.co.uk>"]
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/giantmade/giant-news"
@@ -43,7 +43,7 @@ flake8 = "^6.0.0"
 [[tool.poetry.source]]
 name = "TestPyPi"
 url = "https://test.pypi.org/simple/"
-priority = "secondary"
+priority = "supplemental"
 
 [tool.black]
 line-length = 99


### PR DESCRIPTION
# Changes Summary

This prepares to release the feeds work in [this earlier PR](https://github.com/giantmade/giant-news/pull/48).

- Updates `CHANGELOG.md`
- Bump version number to `1.3.0`.
- Small fix to TestPyPi poetry source.